### PR TITLE
added utf-8 encoding

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,8 @@ ADD ./pom.xml  /usr/src/sentiment/pom.xml
 ADD ./download_datasets.sh  /usr/src/sentiment/download_datasets.sh
 WORKDIR /usr/src/sentiment
 
+ENV LANG C.UTF-8
+
 RUN mvn install
 RUN ./download_datasets.sh
 

--- a/README.md
+++ b/README.md
@@ -45,15 +45,15 @@ Provided processors are basically wrappers around varius sentiment analysis impl
 ## ADDING NEW PROCESSORS
 
 All processors have to be stored in directory:
-> src/main/java/cz/vutbr/mefw/plugins
+> src/main/java/cz/vutbr/mefw/plugins  
 > Example: src/main/java/cz/vutbr/mefw/plugins/SA_lingpipe
 
 If your processor uses additional classes, they should be stored in:
-> src/main/java/cz/vutbr/mefw/plugins/[name_of_processor_group]
+> src/main/java/cz/vutbr/mefw/plugins/[name_of_processor_group]  
 > Example src/main/java/cz/vutbr/mefw/plugins/SA/
 
 Other resources like datasets, libs, etc. belongs in:
-> resources/[name_of_processor_group]
+> resources/[name_of_processor_group]  
 > Example: resources/but_sentiment
 
 


### PR DESCRIPTION
As per suggestion here: 

https://github.com/appropriate/docker-java/blob/aac815a21ffd5690192e06202d6c065a49ed655f/openjdk-8-jre/Dockerfile

and here:

https://github.com/docker-library/openjdk/issues/32

This removed the encoding build errors, but the docker image still doesn't work (just exits). 

Hope this helps!

Ian
